### PR TITLE
remove trailing slash

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -122,4 +122,4 @@ def start():
                 "Invalid URL. Please enter a valid format (e.g., https://some_url.com"
             )
         else:
-            generate_sitemap(url)
+            generate_sitemap(url.rstrip('/'))


### PR DESCRIPTION
Calling `generate_sitemap` with an url with trailing slash (ex: https://www.google.com/) caused a wrong domain comparison.
Fixes #1